### PR TITLE
add fragment cache (to match turbo cache)

### DIFF
--- a/.changeset/petite-cows-smoke.md
+++ b/.changeset/petite-cows-smoke.md
@@ -1,0 +1,5 @@
+---
+'@coldwired/react': minor
+---
+
+add fragment cache

--- a/packages/react/src/root.test.tsx
+++ b/packages/react/src/root.test.tsx
@@ -76,6 +76,34 @@ describe('@coldwired/react', () => {
       root.destroy();
     });
 
+    it('render fragment with component and cache', async () => {
+      document.body.innerHTML = `<${DEFAULT_TAG_NAME}><${REACT_COMPONENT_TAG} ${NAME_ATTRIBUTE}="Counter"></${REACT_COMPONENT_TAG}></${DEFAULT_TAG_NAME}>`;
+      const root = createRoot({
+        loader: (name) => Promise.resolve(manifest[name]),
+        cache: true,
+      });
+      await root.render(document.body).done;
+
+      expect(document.body.innerHTML).toEqual(
+        `<${DEFAULT_TAG_NAME} data-fragment-id="fragment-0"><div><p>Count: 0</p><button>Increment</button></div></${DEFAULT_TAG_NAME}><div id="react-root"></div>`,
+      );
+
+      root.destroy();
+
+      {
+        const root = createRoot({
+          loader: (name) => Promise.resolve(manifest[name]),
+          cache: true,
+        });
+        await root.render(document.body).done;
+
+        expect(document.body.innerHTML).toEqual(
+          `<${DEFAULT_TAG_NAME} data-fragment-id="fragment-0"><div><p>Count: 0</p><button>Increment</button></div></${DEFAULT_TAG_NAME}><div id="react-root"></div>`,
+        );
+        root.destroy();
+      }
+    });
+
     it('render with error boundary', async () => {
       document.body.innerHTML = `<${DEFAULT_TAG_NAME}>
         <${REACT_COMPONENT_TAG} ${NAME_ATTRIBUTE}="Counter"></${REACT_COMPONENT_TAG}>


### PR DESCRIPTION
turbo will aggressively cache pages when rendering and use the cache for history navigation. If used in combination with turbo rendering (you really should override turbo rendering with our implementation of morph), the new cache option will help.

the scenario is as follows:

- A page is rendered with the react fragment
- navigate with turbo to a new page
- turbo caches the page with the fragment containing either react rendered html or it will be empty (depending on the moment)
- navigate back by pressing the back button
- the cached page is reapplied. When coldwired tries to render the react fragment the source of the fragment is pre-rendered html or an empty string instead of JSX

This patch will preserve the fragment JSX source and try to restore it based on dom ids (they will be preserved in turbo cache)